### PR TITLE
Add ActiveJob integration

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+0.4.0
+  - Upgrade to Timberline v0.8.5
+  - Add ActiveJob adapter and Timberline::Rails::ActiveJobWorker
 0.3.0
   - Upgrade to Timberline v0.8.0
 0.2.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,14 @@
 PATH
   remote: .
   specs:
-    timberline-rails (0.2.0)
-      timberline (~> 0.7.0)
+    timberline-rails (0.3.0)
+      timberline (~> 0.8.5)
 
 GEM
   remote: http://rubygems.org/
   specs:
     coderay (1.1.0)
-    daemons (1.1.9)
+    daemons (1.2.3)
     diff-lcs (1.2.5)
     method_source (0.8.2)
     pry (0.9.12.6)
@@ -16,11 +16,11 @@ GEM
       method_source (~> 0.8)
       slop (~> 3.4)
     rake (10.3.2)
-    redis (3.0.7)
+    redis (3.2.2)
     redis-expiring-set (0.1.2)
       redis
-    redis-namespace (1.4.1)
-      redis (~> 3.0.4)
+    redis-namespace (1.5.2)
+      redis (~> 3.0, >= 3.0.4)
     rspec (3.0.0)
       rspec-core (~> 3.0.0)
       rspec-expectations (~> 3.0.0)
@@ -34,13 +34,13 @@ GEM
       rspec-support (~> 3.0.0)
     rspec-support (3.0.0)
     slop (3.5.0)
-    timberline (0.7.0)
+    timberline (0.8.5)
       daemons
       redis
       redis-expiring-set
       redis-namespace
       trollop
-    trollop (2.0)
+    trollop (2.1.2)
     yard (0.8.7.4)
 
 PLATFORMS
@@ -52,3 +52,6 @@ DEPENDENCIES
   rspec (~> 3.0.0)
   timberline-rails!
   yard
+
+BUNDLED WITH
+   1.10.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,10 +7,24 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
+    activejob (4.2.4)
+      activesupport (= 4.2.4)
+      globalid (>= 0.3.0)
+    activesupport (4.2.4)
+      i18n (~> 0.7)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
     coderay (1.1.0)
     daemons (1.2.3)
     diff-lcs (1.2.5)
+    globalid (0.3.6)
+      activesupport (>= 4.1.0)
+    i18n (0.7.0)
+    json (1.8.3)
     method_source (0.8.2)
+    minitest (5.8.2)
     pry (0.9.12.6)
       coderay (~> 1.0)
       method_source (~> 0.8)
@@ -34,6 +48,7 @@ GEM
       rspec-support (~> 3.0.0)
     rspec-support (3.0.0)
     slop (3.5.0)
+    thread_safe (0.3.5)
     timberline (0.8.5)
       daemons
       redis
@@ -41,12 +56,15 @@ GEM
       redis-namespace
       trollop
     trollop (2.1.2)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
     yard (0.8.7.4)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  activejob
   pry
   rake
   rspec (~> 3.0.0)

--- a/README.markdown
+++ b/README.markdown
@@ -19,10 +19,26 @@ configuration in code using `Timberline.configure`. Timberline-Rails adds in
 automatic detection for a config file at `config/timberline.yml` in your Rails
 app, complete with environment support (just like database.yml).
 
-### Timberline::Rails::ActiveRecord and Timberline::Rails::ActiveRecordWorker
+### ActiveJob Integration
+
+Timberline-Rails now includes an adapter and worker so you can use Timberline as
+ActiveJob's queueing backend.
+
+To use, set Timberline as the queue adapter in `config/application.rb` or in one
+of your environment's configs:
+
+    config.active_job.queue_adapter = :timberline
+
+Then, run a worker for each queue that you use.
+
+    # run this script with rails/runner or use some other means to load your Rails environment
+
+    Timberline::Rails::ActiveJobWorker.new.watch("default")
+
+### ActiveRecord Integration
 
 In order to make running jobs in the background as easy as possible,
-Timberline-Rails comes with two new items to help:
+Timberline-Rails comes with two items to help:
 
 #### Timberline::Rails::ActiveRecord
 

--- a/lib/active_job/queue_adapters/timberline_adapter.rb
+++ b/lib/active_job/queue_adapters/timberline_adapter.rb
@@ -1,0 +1,18 @@
+module ActiveJob
+  module QueueAdapters
+    # To use Timberline set the queue_adapter config to +:timberline+.
+    #
+    #   Rails.application.config.active_job.queue_adapter = :timberline
+    class TimberlineAdapter
+      class << self
+        def enqueue(job)
+          Timberline.push job.queue_name, job.serialize
+        end
+
+        def enqueue_at(job, timestamp)
+          raise NotImplementedError
+        end
+      end
+    end
+  end
+end

--- a/lib/timberline-rails.rb
+++ b/lib/timberline-rails.rb
@@ -1,8 +1,10 @@
 require 'timberline'
 require 'timberline/rails/version'
 require 'timberline/rails/exceptions'
+require 'timberline/rails/active_job_worker'
 require 'timberline/rails/active_record'
 require 'timberline/rails/active_record_worker'
+require 'active_job/queue_adapters/timberline_adapter'
 
 class Timberline
   # Re-open the Timberline::Config class from Timberline

--- a/lib/timberline/rails/active_job_worker.rb
+++ b/lib/timberline/rails/active_job_worker.rb
@@ -1,0 +1,13 @@
+class Timberline
+  class Rails
+    class ActiveJobWorker < ::Timberline::Worker
+      def process_item(item)
+        ActiveJob::Base.execute item.contents
+      rescue StandardError => e
+        item.error_reason = e.message
+        item.error_backtrace = e.backtrace
+        error_item(item)
+      end
+    end
+  end
+end

--- a/spec/lib/timberline/rails/active_job_worker_spec.rb
+++ b/spec/lib/timberline/rails/active_job_worker_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+describe Timberline::Rails::ActiveJobWorker do
+  subject do
+    Timberline::Rails::ActiveJobWorker.new.tap do |worker|
+      worker.instance_variable_set :@queue, queue
+    end
+  end
+  let(:queue) { Timberline.queue("fake_queue") }
+  let(:item) do
+    queue.push({ job_class: "SpecSupport::FakeRails::FakeJob",
+                 arguments: [1, 2, 3] })
+    queue.pop
+  end
+
+  describe "#process_item" do
+    it "uses ActiveJob to execute the item contents" do
+      expect(ActiveJob::Base).to receive(:execute).with(item.contents)
+      subject.process_item(item)
+    end
+
+    context "If the method raises an exception of its own" do
+      before do
+        allow_any_instance_of(SpecSupport::FakeRails::FakeJob).to receive(:perform) { raise "This doesn't work" }
+      end
+
+      it "errors the item" do
+        expect(subject).to receive(:error_item).with(item)
+        subject.process_item(item)
+      end
+
+      it "provides an error_reason" do
+        expect { subject.process_item(item) }.to raise_error(Timberline::ItemErrored)
+        expect(item.error_reason).to include("This doesn't work")
+      end
+
+      it "provides an error_backtrace" do
+        expect { subject.process_item(item) }.to raise_error(Timberline::ItemErrored)
+        expect(item.error_backtrace).to be_a Array
+      end
+    end
+  end
+end

--- a/spec/lib/timberline/rails/active_record_worker_spec.rb
+++ b/spec/lib/timberline/rails/active_record_worker_spec.rb
@@ -1,7 +1,11 @@
 require 'spec_helper'
 
 describe Timberline::Rails::ActiveRecordWorker do
-  subject { Timberline::Rails::ActiveRecordWorker.new("fake_queue") }
+  subject do
+    Timberline::Rails::ActiveRecordWorker.new.tap do |worker|
+      worker.instance_variable_set :@queue, queue
+    end
+  end
   let(:queue) { Timberline.queue("fake_queue") }
   let(:item) do 
     queue.push({ model_name: "SpecSupport::FakeRails::FakeModel",

--- a/spec/support/fake_rails.rb
+++ b/spec/support/fake_rails.rb
@@ -1,3 +1,8 @@
+require 'active_job'
+
+ActiveJob::Base.logger = nil
+ActiveJob::Base.queue_adapter = :timberline
+
 module SpecSupport
   module FakeRails
     def self.create_fake_env
@@ -12,6 +17,13 @@ module SpecSupport
 
     def self.destroy_fake_env
       Object.send(:remove_const, :Rails)
+    end
+
+    class FakeJob < ActiveJob::Base
+      queue_as :fake_queue
+
+      def perform(*args)
+      end
     end
 
     class FakeModel

--- a/timberline-rails.gemspec
+++ b/timberline-rails.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency "timberline", "~> 0.8.0"
+  s.add_runtime_dependency "timberline", "~> 0.8.5"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec", '~> 3.0.0'

--- a/timberline-rails.gemspec
+++ b/timberline-rails.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency "timberline", "~> 0.8.5"
 
+  s.add_development_dependency "activejob"
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec", '~> 3.0.0'
   s.add_development_dependency "pry"


### PR DESCRIPTION
This adds ActiveJob integration to Timberline-Rails by way of a queue adapter and a basic worker that dispatches items to their respective job classes.

/cc @wellbredgrapefruit @amoslanka