### PR TITLE
Update activejob from 5.0.2 -> 5.0.7.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,23 +7,24 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
-    activejob (5.0.2)
-      activesupport (= 5.0.2)
+    activejob (5.0.7.1)
+      activesupport (= 5.0.7.1)
       globalid (>= 0.3.6)
-    activesupport (5.0.2)
+    activesupport (5.0.7.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (~> 0.7)
+      i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     coderay (1.1.0)
-    concurrent-ruby (1.0.5)
+    concurrent-ruby (1.1.4)
     daemons (1.2.4)
     diff-lcs (1.2.5)
-    globalid (0.4.0)
+    globalid (0.4.2)
       activesupport (>= 4.2.0)
-    i18n (0.8.1)
+    i18n (1.5.2)
+      concurrent-ruby (~> 1.0)
     method_source (0.8.2)
-    minitest (5.10.1)
+    minitest (5.11.3)
     pry (0.9.12.6)
       coderay (~> 1.0)
       method_source (~> 0.8)
@@ -55,7 +56,7 @@ GEM
       redis-namespace
       trollop
     trollop (2.1.2)
-    tzinfo (1.2.3)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
     yard (0.9.12)
 


### PR DESCRIPTION
Updated activejob because of a security alert

![image 1](https://user-images.githubusercontent.com/6364181/51193554-b74a8080-18ae-11e9-93ad-3392acee835c.png)
